### PR TITLE
Add return for avoiding call next(action) multiple times

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -31,6 +31,7 @@ function getMiddlewareFunction(cases) {
             for (const caseItem of caseItems) {
                 caseItem.handler(api, next, action);
             }
+            return;
         }
         return next(action);
     };

--- a/src/index.ts
+++ b/src/index.ts
@@ -99,6 +99,7 @@ function getMiddlewareFunction<S, D extends Dispatch = Dispatch, A extends Actio
       for (const caseItem of caseItems) {
         caseItem.handler(api, next, action);
       }
+      return;
     }
     return next(action);
   };

--- a/test/jest/Test_01.spec.ts
+++ b/test/jest/Test_01.spec.ts
@@ -30,6 +30,7 @@ it('Passes through action', () => {
   const action = { type: "ACTION_01" }
   invoke(action);
   expect(next).toHaveBeenCalledWith({...action, meta: "called"});
+  expect(next).toHaveBeenCalledTimes(1);
 })
 
 // ----------------------------------------------------------------------------
@@ -39,6 +40,7 @@ it('ActionCreator type', () => {
   const {next, invoke} = create(TestMiddleware_01);
   invoke(ActionCreators_01.action_01());
   expect(next).toHaveBeenCalledWith({type: "ACTION_01", meta: "called"});
+  expect(next).toHaveBeenCalledTimes(1);
 })
 
 // ----------------------------------------------------------------------------
@@ -50,6 +52,7 @@ it('Action with parameter', () => {
   const param: ActionParam_02 = { value: "value" };
   invoke(ActionCreators_01.action_02(param));
   expect(next).toHaveBeenCalledWith({type: "ACTION_02", payload: param, meta: "called"});
+  expect(next).toHaveBeenCalledTimes(1);
 })
 
 // ----------------------------------------------------------------------------
@@ -63,6 +66,7 @@ it('Call cases', () => {
 
   invoke( ActionCreators_01.action_cases_02() );
   expect(next).toHaveBeenCalledWith({type: "ACTION_CASES_02", meta: "called"});
+  expect(next).toHaveBeenCalledTimes(2);
 })
 
 // ----------------------------------------------------------------------------
@@ -74,6 +78,7 @@ it('Add cases multiple times', () => {
   invoke( ActionCreators_01.action_03() );
   expect(next).toHaveBeenNthCalledWith(1, {type: "ACTION_03", meta: "1st"});
   expect(next).toHaveBeenNthCalledWith(2, {type: "ACTION_03", meta: "2nd"});
+  expect(next).toHaveBeenCalledTimes(2);
 })
 
 // ----------------------------------------------------------------------------
@@ -85,4 +90,5 @@ it('No target type', () => {
   invoke(action);
   expect(next).toHaveBeenCalledWith(action);
   expect(next).not.toHaveBeenCalledWith({...action, meta: "called"});
+  expect(next).toHaveBeenCalledTimes(1);
 })


### PR DESCRIPTION
BugFix
- If the target case found on middleware, avoid doing next(action) since the case should have this ability